### PR TITLE
allow NULL values

### DIFF
--- a/contao-module/dca/tl_module.php
+++ b/contao-module/dca/tl_module.php
@@ -27,7 +27,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['leadOptInSuccessMessage'] = array
     'exclude'   => true,
     'inputType' => 'textarea',
     'eval'      => array('tl_class' => 'long', 'rte' => 'tinyMCE'),
-    'sql'       => "text NOT NULL",
+    'sql'       => "text NULL",
 );
 
 $GLOBALS['TL_DCA']['tl_module']['fields']['leadOptInErrorMessage'] = array
@@ -36,7 +36,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['leadOptInErrorMessage'] = array
     'exclude'   => true,
     'inputType' => 'textarea',
     'eval'      => array('tl_class' => 'long', 'rte' => 'tinyMCE'),
-    'sql'       => "text NOT NULL",
+    'sql'       => "text NULL",
 );
 
 $GLOBALS['TL_DCA']['tl_module']['fields']['leadOptInSuccessNotification'] = array


### PR DESCRIPTION
When using `NOT NULL` you always need to also set a default - or allow NULL values, otherwise the following error will occur:
```
Doctrine\DBAL\Exception\NotNullConstraintViolationException:
An exception occurred while executing 'INSERT INTO tl_module (...)':

SQLSTATE[HY000]: General error: 1364 Field 'leadOptInSuccessMessage' doesn't have a default value

  at vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:123
  at Doctrine\DBAL\Driver\AbstractMySQLDriver->convertException('An exception occurred while executing \'INSERT INTO tl_module (...) VALUES (...)\':SQLSTATE[HY000]: General error: 1364 Field \'leadOptInSuccessMessage\' doesn\'t have a default value', object(PDOException))
     (vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:184)
  at Doctrine\DBAL\DBALException::wrapException(object(Driver), object(PDOException), 'An exception occurred while executing \'INSERT INTO tl_module (...) VALUES (...)\':SQLSTATE[HY000]: General error: 1364 Field \'leadOptInSuccessMessage\' doesn\'t have a default value')
     (vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:158)
  at Doctrine\DBAL\DBALException::driverExceptionDuringQuery(object(Driver), object(PDOException), 'INSERT INTO tl_module (...) VALUES (...)', array())
     (vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:943)
  at Doctrine\DBAL\Connection->executeQuery('INSERT INTO tl_module (...) VALUES (...)')
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php:277)
  at Contao\Database\Statement->query()
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php:251)
  at Contao\Database\Statement->execute()
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:691)
  at Contao\DC_Table->create()
     (vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php:618)
  at Contao\Backend->getBackendModule('themes', null)
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:169)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:48)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:150)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:67)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:198)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (web/app_dev.php:83)
```